### PR TITLE
fix: removes hover on inactive link

### DIFF
--- a/blocks/header/__navigation-link/_active/header__navigation-link_active.css
+++ b/blocks/header/__navigation-link/_active/header__navigation-link_active.css
@@ -1,7 +1,6 @@
 .header__navigation-link_active{
     position: relative;
 }
-    
 .header__navigation-link_active::after{
     content: "";
     position: absolute;

--- a/blocks/header/__navigation-link/header__navigation-link.css
+++ b/blocks/header/__navigation-link/header__navigation-link.css
@@ -3,11 +3,9 @@
     text-decoration: none;
     transition: var(--common-transition);
 }
-
-.header__navigation-link:hover{
+.header__navigation-link:not(.header__navigation-link_active):hover{
     color: rgb(178, 40, 102);
 }
-
-.header__navigation-link:active{
+.header__navigation-link:not(.header__navigation-link_active):active{
     color: rgb(255, 255, 255, 0.5);
 }


### PR DESCRIPTION
## Description of the problem

 The project faced a problem with a color-changing link to the main page that leads nowhere. When you hover or hold down the cursor on this link, it changes color, which can lead to user confusion and gives the impression that the link has the functionality to go to another page, although it does not.

## Solution to the problem
The following changes were made to resolve this issue:

 Changes have been made to the `header__navigation-link.css` file, using the CSS `:not()` pseudo-class to exclude the` header__navigation-link_active` state in the hovered and active link states:
  ```css
.header__navigation-link:not(.header__navigation-link_active):hover{
   color: rgb(178, 40, 102);
}
```
```css
.header__navigation-link:not(.header__navigation-link_active):active{
    color: rgb(255, 255, 255, 0.5);
}
```
I tested the changes in the live server to ensure that the link to the main page does not respond to hovering and active state.
This pull request resolves [#31](https://github.com/p-foundation/pink-app/issues/31)


